### PR TITLE
Check groups based on length

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -125,8 +125,8 @@ with open(os.path.join(service_account_path, 'token')) as fp:
 
 c.OpenShiftOAuthenticator.client_secret = client_secret
 
-allowed_groups = os.environ.get('JUPYTERHUB_ALLOWED_GROUPS')
-admin_groups = os.environ.get('JUPYTERHUB_ADMIN_GROUPS')
+allowed_groups = os.environ.get('JUPYTERHUB_ALLOWED_GROUPS', '')
+admin_groups = os.environ.get('JUPYTERHUB_ADMIN_GROUPS', '')
 if allowed_groups:
     c.OpenShiftOAuthenticator.allowed_groups = set(allowed_groups.split(','))
 if admin_groups:


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

The original code was safe in case when the env vars did not exist or contained the list of groups, but not in case where they exist and are empty.

This PR fixes that - empty env vars are treated the same as if they do not exist.

## Description

<!--- Describe your changes in detail -->
