### PR TITLE
Skip login page and enable auth state

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -103,6 +103,8 @@ c.KubeSpawner.singleuser_extra_containers = [
 
 from oauthenticator.openshift import OpenShiftOAuthenticator
 c.JupyterHub.authenticator_class = OpenShiftOAuthenticator
+c.Authenticator.auto_login = True
+c.Authenticator.enable_auth_state = True
 
 # Override scope as oauthenticator code doesn't set it correctly.
 # Need to lodge a PR against oauthenticator to have this fixed.


### PR DESCRIPTION
## Related Issues and Dependencies

This will need updated manifest as we need the following env vars to be set to values consistent accross deployments

* ```CONFIGPROXY_AUTH_TOKEN ```
* ```JPY_COOKIE_SECRET```
* ```JUPYTERHUB_CRYPT_KEY```

## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

<!--- Describe your changes in detail -->
