### PR TITLE
Added leader election to JH image

### DIFF
--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,0 +1,23 @@
+#!/bin/bash
+ME="$(cat /etc/hostname)"
+
+# Check the endpoint opened by the sidecar image gcr.io/google_containers/leader-elector:0.5.
+# The image will contain a JSON with the name of the leader
+function get_leader() {
+  echo "$(curl http://localhost:4040 2> /dev/null | python3 -c "import sys, json; print(json.load(sys.stdin)['name'])")"
+}
+
+# Wait till the leader server is ready
+function wait_service() {
+    while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:4040)" != "200" ]]; do sleep 1; done
+}
+
+wait_service
+echo "Waiting to become leader..."
+
+until [ "${ME}" == "$(get_leader)" ]; do
+  sleep 6
+done
+
+echo "Assigned as new leader"
+exec /opt/app-root/builder/run


### PR DESCRIPTION
## Related Issues and Dependencies

[RHODS-767](https://issues.redhat.com/browse/RHODS-767)

## This introduces a breaking change

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Added the s2i run step to check if the image is the leader. By checking the port opened by the sidecar leader container only the leader will start the execution.

## This Pull Request implements

* Add script to check the  [leader election strategy](https://kubernetes.io/blog/2016/01/simple-leader-election-with-kubernetes/)

## Description

Based on the work of of [Sean](https://github.com/Xaenalt/jupyterhub-odh-ha) add check method for the kubernetes leader election pattern.

This PR is linked to the [Added sidecar leader election on JH PR](https://github.com/opendatahub-io/odh-manifests/pull/460)

## Testing

This image could be built with the following command:

```
s2i build git@github.com:lucferbux/jupyterhub-odh.git --ref feature/add-leader-election --context-dir / quay.io/odh-jupyterhub/jupyterhub:v3.5.3 [registry]
```

For further info you can check this [test log](https://docs.google.com/document/d/1mpDir4GjhSrs3awMOsNKmD3tAME2uks9mW0Gh1q4CKc/edit?usp=sharing)