### PR TITLE
Add idle-culler support to JupyterHub Config

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ openshift = "==0.11.2"
 jupyterhub-singleuser-profiles = "==0.5.1"
 oauthenticator = {ref = "d98936da37569b7bb400c6854b07041dce3e7f87",git = "https://github.com/opendatahub-io/oauthenticator.git", editable = true}
 jupyterhub-traefik-proxy = {ref = "b468da04bf0057e9baeb458de6c3f9f677cfb79e", git = "https://github.com/opendatahub-io/traefik-proxy.git", editable = true}
+jupyterhub-idle-culler = "==1.1"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5ac4d8e058a0116bc6d43ba117c8624f258e1f756b128319720f0a44f9606d74"
+            "sha256": "e8cf9f860a403c2534aafc972632f7492ed96acb1b7b6c2eab40bed62db4922f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -195,6 +195,9 @@
             "version": "==20.10.2"
         },
         "connexion": {
+            "extras": [
+                "swagger-ui"
+            ],
             "hashes": [
                 "sha256:0105b03ea1c54fa0e8160825c729e416b8bd6bf3f007981b04c92ce6d5ae990b",
                 "sha256:656d451e21df5f38c4ddb826b805ebe5a641423253f7f33c798ca3ec1cb94cda"
@@ -411,6 +414,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.4.2"
+        },
+        "jupyterhub-idle-culler": {
+            "hashes": [
+                "sha256:45bceffeea8758b60e1f60650bc3de0d0d1e5f774623793db268ded1fa0cbdcb",
+                "sha256:600b2713f90ecc475f690747d1ec02bcae8f44fa7f3e51a71e400727895631d8"
+            ],
+            "index": "pypi",
+            "version": "==1.1"
         },
         "jupyterhub-singleuser-profiles": {
             "hashes": [
@@ -868,6 +879,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.4.22"
+        },
+        "swagger-ui-bundle": {
+            "hashes": [
+                "sha256:f5255f786cde67a2638111f4a7d04355836743198a83c4ecbe815d9fc384b0c8",
+                "sha256:f5691167f2e9f73ecbe8229a89454ae5ea958f90bb0d4583ed7adaae598c4122"
+            ],
+            "version": "==0.0.8"
         },
         "toml": {
             "hashes": [


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Adds the JupyterHub Idle Culler as an external service

## Description

This PR adds the idle culler as an external service and also exposes its api-token into a secret the the idle culler can read from.

This is a replacement for #97 to resolve conflicts in @mroman-redhat'S absence