### PR TITLE
Set notebook namespace to None if empty

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -10,6 +10,8 @@ import distutils
 c.JupyterHub.cleanup_servers = False
 
 custom_notebook_namespace = os.environ.get('NOTEBOOK_NAMESPACE')
+if not custom_notebook_namespace:
+    custom_notebook_namespace = None;
 
 import uuid
 jsp_api_dict = {


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Checks implemented for setting notebook namespace require it to be None to set default namespace

If the `NOTEBOOK_NAMESPACE` env var is set, but is empty string, default namespace is not set and the OpenShift API calls are trying to get the resources on cluster level. 

## Description

<!--- Describe your changes in detail -->
