### PR TITLE
Update s2i assembly to support multiple template html files

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -23,6 +23,6 @@ mkdir jsp-ui
 cp -a ${JSP_UI_SRC_PATH}/build/. /opt/app-root/share/jupyterhub/static/jsp-ui
 
 cd ${JSP_UI_SRC_PATH}/templates/
-yes | cp -rf spawn.html /opt/app-root/share/jupyterhub/templates/
+yes | cp -rf *.html /opt/app-root/share/jupyterhub/templates/
 
 fix-permissions /opt/app-root


### PR DESCRIPTION
## Related Issues and Dependencies

None

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Allows for multiple html templates to override existing templates during s2i assembly

## Description

Change the command that copies only the `spawn.html` file for the src templates directory to copy all html files from that directory. This allows for custom implementations of the other paths (admin, spawn-pending, etc).
