### PR TITLE
Add in cpu_modes in the spawn call

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -237,7 +237,8 @@ def apply_pod_profile(spawner, pod):
   spawner.single_user_profiles.load_profiles(username=spawner.user.name)
   profile = spawner.single_user_profiles.get_merged_profile(spawner.image, user=spawner.user.name, size=spawner.deployment_size)
   gpu_types = spawner.single_user_profiles.get_gpu_types()
-  return SingleuserProfiles.apply_pod_profile(spawner.user.name, pod, profile, gpu_types, DEFAULT_MOUNT_PATH, spawner.gpu_mode)
+  cpu_types = spawner.single_user_profiles.get_cpu_types()
+  return SingleuserProfiles.apply_pod_profile(spawner.user.name, pod, profile, gpu_types, cpu_types, DEFAULT_MOUNT_PATH, spawner.gpu_mode)
 
 def setup_environment(spawner):
     spawner.set_from_profile()


### PR DESCRIPTION
This is needed for https://github.com/opendatahub-io/jupyterhub-singleuser-profiles/pull/222

This allows the spawner to use the new cpu_types field to add the soft anti-affinity for pods that don't request a GPU

## Related Issues and Dependencies

https://github.com/opendatahub-io/jupyterhub-singleuser-profiles/pull/222

## This introduces a breaking change

- [X] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Will need to also apply https://github.com/opendatahub-io/jupyterhub-singleuser-profiles/pull/222 since the function signature changed

## This Pull Request implements

This adds in the cpu_types parameter for apply_pod_profile call as per https://github.com/opendatahub-io/jupyterhub-singleuser-profiles/pull/222

## Description

Overall change is to apply a soft anti-affinity for nodes tagged as GPU nodes when a notebook pod isn't requesting GPUs. The soft anti-affinity will allow users to prefer non-GPU nodes for non-GPU workloads unless there's a shortage of resources
